### PR TITLE
fixed logging for embedded mongo 

### DIFF
--- a/vertx-pojongo/build.gradle
+++ b/vertx-pojongo/build.gradle
@@ -3,9 +3,10 @@ dependencies {
   compile project(':vertx-pojo-mapper-common-test')
   compile project(':vertx-pojo-mapper-json')
   compile group: 'io.vertx', name: 'vertx-mongo-embedded-db', version:vertxVersion
+  compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.7'
   
   testCompile project(':vertx-pojo-mapper-json').sourceSets.test.output
-  testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.12'
+  
 }
 
 test {

--- a/vertx-pojongo/pom.xml
+++ b/vertx-pojongo/pom.xml
@@ -50,10 +50,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.12</version>
-			<scope>test</scope>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.7</version>
 		</dependency>
 		
 	</dependencies>

--- a/vertx-pojongo/src/main/java/de/braintags/vertx/jomnigate/mongo/init/MongoDataStoreInit.java
+++ b/vertx-pojongo/src/main/java/de/braintags/vertx/jomnigate/mongo/init/MongoDataStoreInit.java
@@ -14,6 +14,8 @@ package de.braintags.vertx.jomnigate.mongo.init;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+
 import de.braintags.vertx.jomnigate.IDataStore;
 import de.braintags.vertx.jomnigate.init.AbstractDataStoreInit;
 import de.braintags.vertx.jomnigate.init.DataStoreSettings;
@@ -24,17 +26,21 @@ import de.braintags.vertx.jomnigate.mapping.impl.keygen.DefaultKeyGenerator;
 import de.braintags.vertx.jomnigate.mongo.MongoDataStore;
 import de.braintags.vertx.util.exception.InitException;
 import de.braintags.vertx.util.security.crypt.impl.StandardEncoder;
+import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.IMongodConfig;
 import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
 import de.flapdoodle.embed.process.runtime.Network;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.SLF4JLogDelegateFactory;
 import io.vertx.ext.mongo.MongoClient;
 
 /**
@@ -238,7 +244,12 @@ public class MongoDataStoreInit extends AbstractDataStoreInit implements IDataSt
       try {
         IMongodConfig config = new MongodConfigBuilder().version(Version.Main.PRODUCTION)
             .net(new Net(localPort, Network.localhostIsIPv6())).build();
-        exe = MongodStarter.getDefaultInstance().prepare(config);
+        Logger logger = (Logger) new SLF4JLogDelegateFactory()
+            .createDelegate(MongoDataStoreInit.class.getCanonicalName()).unwrap();
+
+        IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder().defaultsWithLogger(Command.MongoD, logger).build();
+
+        exe = MongodStarter.getInstance(runtimeConfig).prepare(config);
         exe.start();
       } catch (IOException e) {
         throw new RuntimeException(e);


### PR DESCRIPTION
This fixes #46 

It's now possible to remove the spammy mongod output from the logging.

See https://github.com/vert-x3/vertx-embedded-mongo-db/pull/4