### PR TITLE
Feature/clear database on init

### DIFF
--- a/vertx-pojo-mapper-common-test/src/main/java/de/braintags/vertx/jomnigate/testdatastore/AllTestsCommon.java
+++ b/vertx-pojo-mapper-common-test/src/main/java/de/braintags/vertx/jomnigate/testdatastore/AllTestsCommon.java
@@ -30,7 +30,8 @@ import de.braintags.vertx.jomnigate.testdatastore.typehandler.TypeHandlerTestSui
 @SuiteClasses({ TestBaseTest.class, TestSimpleMapper.class, TestStoreObject.class, TestQueryHelper.class,
     TestIndex.class, TestRoundtrip.class, TestSimpleMapperQuery.class, TestOnlyIdMapper.class, TestTrigger.class,
     TypeHandlerTestSuite.class, TestMassInsert.class, TestKeyGenerator.class, TestGeoSearch.class, TestEncoder.class,
-    TestEmbeddedEntity.class, TestListExtrems.class, TestFieldConditionCache.class, TestQueryInterator.class })
+    TestEmbeddedEntity.class, TestListExtrems.class, TestFieldConditionCache.class, TestQueryInterator.class,
+    TestClearDatastore.class })
 public class AllTestsCommon {
 
 }

--- a/vertx-pojo-mapper-common-test/src/main/java/de/braintags/vertx/jomnigate/testdatastore/IDatastoreContainer.java
+++ b/vertx-pojo-mapper-common-test/src/main/java/de/braintags/vertx/jomnigate/testdatastore/IDatastoreContainer.java
@@ -14,6 +14,7 @@
 package de.braintags.vertx.jomnigate.testdatastore;
 
 import de.braintags.vertx.jomnigate.IDataStore;
+import de.braintags.vertx.jomnigate.init.DataStoreSettings;
 import de.braintags.vertx.jomnigate.testdatastore.typehandler.json.AbstractTypeHandlerTest;
 import de.braintags.vertx.jomnigate.typehandler.ITypeHandler;
 import io.vertx.core.AsyncResult;
@@ -31,6 +32,8 @@ public interface IDatastoreContainer {
   public static final String PROPERTY = "IDatastoreContainer";
 
   public IDataStore getDataStore();
+
+  public DataStoreSettings createSettings();
 
   public void startup(Vertx vertx, Handler<AsyncResult<Void>> handler);
 

--- a/vertx-pojo-mapper-common-test/src/main/java/de/braintags/vertx/jomnigate/testdatastore/TestClearDatastore.java
+++ b/vertx-pojo-mapper-common-test/src/main/java/de/braintags/vertx/jomnigate/testdatastore/TestClearDatastore.java
@@ -1,0 +1,106 @@
+/*
+ * #%L
+ * vertx-pojo-mapper-mysql
+ * %%
+ * Copyright (C) 2017 Braintags GmbH
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package de.braintags.vertx.jomnigate.testdatastore;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import de.braintags.vertx.jomnigate.IDataStore;
+import de.braintags.vertx.jomnigate.dataaccess.query.IQuery;
+import de.braintags.vertx.jomnigate.dataaccess.query.ISearchCondition;
+import de.braintags.vertx.jomnigate.dataaccess.write.IWrite;
+import de.braintags.vertx.jomnigate.dataaccess.write.IWriteResult;
+import de.braintags.vertx.jomnigate.init.DataStoreSettings;
+import de.braintags.vertx.jomnigate.init.IDataStoreInit;
+import de.braintags.vertx.jomnigate.testdatastore.mapper.SimpleMapper;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+/**
+ * Unit test for {@link DataStoreSettings#isClearDatabaseOnInit()}
+ * 
+ * @author sschmitt
+ * 
+ */
+@RunWith(VertxUnitRunner.class)
+public class TestClearDatastore {
+
+  /**
+   * Ensure that records remain between datastore initialziations if 'clearDatabaseOnInit' is false
+   * 
+   * @param context
+   */
+  @Test
+  public void testDatastore_noClearOnInit(TestContext context) {
+    testDatastore(false, context);
+  }
+
+  /**
+   * Ensure that records remain between datastore initialziations if 'clearDatabaseOnInit' is true
+   * 
+   * @param context
+   */
+  @Test
+  public void testDatastore_clearOnInit(TestContext context) {
+    testDatastore(true, context);
+  }
+
+  /**
+   * Initializes a datastore and writes a record to it. Aftewards, initializes a second datastore with the same settings
+   * and checks if the record is still there.
+   * If shouldClear is 'true', it should not be there anymore, otherwise it must still be there.
+   * 
+   * @param shouldClear
+   *          value of the 'clearDatabaseOnInit' setting
+   * @param context
+   *          the test context
+   */
+  private void testDatastore(boolean shouldClear, TestContext context) {
+    DataStoreSettings settings = TestHelper.getDatastoreContainer(context).createSettings();
+    settings.setClearDatabaseOnInit(shouldClear);
+
+    IDataStoreInit init;
+    try {
+      init = settings.getDatastoreInit().newInstance();
+    } catch (InstantiationException | IllegalAccessException e1) {
+      context.fail(e1);
+      return;
+    }
+
+    init.initDataStore(TestHelper.vertx, settings, context.asyncAssertSuccess((IDataStore datastore) -> {
+      IWrite<SimpleMapper> write = datastore.createWrite(SimpleMapper.class);
+      SimpleMapper mapper = new SimpleMapper();
+      mapper.name = "Test";
+      write.add(mapper);
+      write.save(context.asyncAssertSuccess((IWriteResult writeResult) -> {
+        IDataStoreInit init2;
+        try {
+          init2 = settings.getDatastoreInit().newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+          context.fail(e);
+          return;
+        }
+
+        init2.initDataStore(TestHelper.vertx, settings, context.asyncAssertSuccess((IDataStore datastore2) -> {
+          IQuery<SimpleMapper> query = datastore2.createQuery(SimpleMapper.class);
+          query.setSearchCondition(ISearchCondition.isEqual("id", mapper.id));
+          query.execute(context.asyncAssertSuccess(queryResult -> {
+            context.assertEquals(queryResult.iterator().hasNext(), !shouldClear,
+                "The record saved on one datastore should " + (shouldClear ? "not" : "still")
+                    + " be accessible on a new datastore if 'clearDatabaseOnInit' is " + shouldClear);
+          }));
+        }));
+      }));
+    }));
+  }
+}

--- a/vertx-pojo-mapper-common/src/main/java/de/braintags/vertx/jomnigate/init/AbstractDataStoreInit.java
+++ b/vertx-pojo-mapper-common/src/main/java/de/braintags/vertx/jomnigate/init/AbstractDataStoreInit.java
@@ -110,6 +110,17 @@ public abstract class AbstractDataStoreInit implements IDataStoreInit {
   }
 
   /**
+   * Get if the database should be completely wiped on initialization, deleting everything stored beforehand. Should
+   * only be
+   * used for unit tests to ensure an empty database for each test.
+   * 
+   * @return if the database should be cleared on initialization
+   */
+  protected boolean isClearDatabaseOnInit() {
+    return settings.isClearDatabaseOnInit();
+  }
+
+  /**
    * Get a property with the given key as boolean
    * 
    * @param name

--- a/vertx-pojo-mapper-common/src/main/java/de/braintags/vertx/jomnigate/init/DataStoreSettings.java
+++ b/vertx-pojo-mapper-common/src/main/java/de/braintags/vertx/jomnigate/init/DataStoreSettings.java
@@ -32,6 +32,7 @@ public class DataStoreSettings {
   private Properties properties = new Properties();
   private String databaseName;
   private List<EncoderSettings> encoders = new ArrayList<>();
+  private boolean clearDatabaseOnInit = false;
 
   /**
    * Standard constructor needed for saving as local file
@@ -138,5 +139,28 @@ public class DataStoreSettings {
    */
   public void setEncoders(List<EncoderSettings> encoders) {
     this.encoders = encoders;
+  }
+
+  /**
+   * Get if the database should be completely wiped on initialization, deleting everything stored beforehand. Should
+   * only be
+   * used for unit tests to ensure an empty database for each test.
+   * 
+   * @return if the database should be cleared on initialization
+   */
+  public boolean isClearDatabaseOnInit() {
+    return clearDatabaseOnInit;
+  }
+
+  /**
+   * Set if the database should be completely wiped on initialization, deleting everything stored beforehand. Should
+   * only be
+   * used for unit tests to ensure an empty database for each test.
+   * 
+   * @param clearDatabaseOnInit
+   *          if the database should be cleared on initialization
+   */
+  public void setClearDatabaseOnInit(boolean clearDatabaseOnInit) {
+    this.clearDatabaseOnInit = clearDatabaseOnInit;
   }
 }

--- a/vertx-pojo-mapper-mysql/src/test/java/de/braintags/vertx/jomnigate/mysql/MySqlDataStoreContainer.java
+++ b/vertx-pojo-mapper-mysql/src/test/java/de/braintags/vertx/jomnigate/mysql/MySqlDataStoreContainer.java
@@ -104,7 +104,7 @@ public class MySqlDataStoreContainer extends AbstractDataStoreContainer {
     LOGGER.info("Startup of " + getClass().getSimpleName());
     try {
       if (datastore == null) {
-        DataStoreSettings settings = MySqlDataStoreinit.createSettings();
+        DataStoreSettings settings = createSettings();
         IDataStoreInit dsInit = settings.getDatastoreInit().newInstance();
         dsInit.initDataStore(vertx, settings, initResult -> {
           if (initResult.failed()) {
@@ -122,6 +122,11 @@ public class MySqlDataStoreContainer extends AbstractDataStoreContainer {
       LOGGER.error("", e);
       handler.handle(Future.failedFuture(e));
     }
+  }
+
+  @Override
+  public DataStoreSettings createSettings() {
+    return MySqlDataStoreinit.createSettings();
   }
 
   /*

--- a/vertx-pojongo/src/test/java/de/braintags/vertx/jomnigate/mongo/vertxunit/MongoDataStoreContainer.java
+++ b/vertx-pojongo/src/test/java/de/braintags/vertx/jomnigate/mongo/vertxunit/MongoDataStoreContainer.java
@@ -77,7 +77,8 @@ public class MongoDataStoreContainer extends AbstractDataStoreContainer {
     }
   }
 
-  private DataStoreSettings createSettings() {
+  @Override
+  public DataStoreSettings createSettings() {
     DataStoreSettings settings = MongoDataStoreInit.createDefaultSettings();
     settings.setDatabaseName("UnitTestDatabase");
     settings.getProperties().put(MongoDataStoreInit.CONNECTION_STRING_PROPERTY,


### PR DESCRIPTION
Added option for datastores to clear everything on initialization, useful for unit tests so they can start on a clear state